### PR TITLE
introduce Restriction object for choices

### DIFF
--- a/examples/use-choices.ts
+++ b/examples/use-choices.ts
@@ -1,13 +1,10 @@
-import { parseArgs } from "../parse-args.ts";
-import { buildHelp } from "../build-help.ts";
+import { parseArgs, Restriction } from "../parse-args.ts";
 
 const directions = ["north", "south", "east", "west"] as const;
-type DirectionType = typeof directions[number];
 
 const options = {
+  description: "use choices",
   string: ["name", "direction"],
-  boolean: ["color"],
-  negatable: ["color"],
   required: ["name", "direction"],
   default: { name: "world" },
   flagDescription: {
@@ -16,16 +13,16 @@ const options = {
 } as const;
 
 function main() {
-  // args is of type { name: string, direction: string }
-  const args = parseArgs(Deno.args, options);
-  if (!directions.includes(args.direction as DirectionType)) {
-    console.log(buildHelp(options));
-    console.error(`Invalid direction: "${args.direction}" is not one of ${JSON.stringify(directions)}`);
-    Deno.exit(1);
-  }
+  // In actual code, you don't need to write such types, you can leave it to inference.
+  type WantType = { name: string; direction: "north" | "south" | "east" | "west" };
+  type GotType = { name: string; direction: string };
 
-  // args2 is of type { name: string, direction: DirectionType }
-  const args2 = { ...args, direction: args.direction as DirectionType };
+  // parse arguments
+  const args: GotType = parseArgs(Deno.args, options);
+
+  // restrict to desired type
+  const restriction = new Restriction(options);
+  const args2: WantType = { ...args, direction: restriction.choices(args.direction, directions) };
 
   console.dir(args2, { depth: null });
 }

--- a/parse-args.ts
+++ b/parse-args.ts
@@ -213,6 +213,7 @@ export function parseArgs<
   return parsed;
 }
 
+/** Restriction class for type checking */
 export class Restriction {
   constructor(
     private readonly options: Options,

--- a/parse-args.ts
+++ b/parse-args.ts
@@ -212,3 +212,17 @@ export function parseArgs<
   });
   return parsed;
 }
+
+export class Restriction {
+  constructor(
+    private readonly options: Options,
+    private readonly handler: Handler = denoHandler,
+  ) {}
+
+  choices<const KS extends readonly string[]>(value: string, candidates: KS): string[] extends KS ? never : KS[number] {
+    if (!candidates.includes(value)) {
+      this.handler.terminate({ message: `${value} is not one of ${JSON.stringify(candidates)}`, code: 1 });
+    }
+    return value as string[] extends KS ? never : KS[number];
+  }
+}

--- a/parse-args.ts
+++ b/parse-args.ts
@@ -217,12 +217,16 @@ export function parseArgs<
 export class Restriction {
   constructor(
     private readonly options: Options,
-    private readonly handler: Handler = denoHandler,
+    private readonly supressHelp: boolean = false, // supress help message if error
+    private readonly _handler: Handler = denoHandler,
   ) {}
 
   choices<const KS extends readonly string[]>(value: string, candidates: KS): string[] extends KS ? never : KS[number] {
     if (!candidates.includes(value)) {
-      this.handler.terminate({ message: `${value} is not one of ${JSON.stringify(candidates)}`, code: 1 });
+      if (!this.supressHelp) {
+        this._handler.showHelp(this.options);
+      }
+      this._handler.terminate({ message: `"${value}" is not one of ${JSON.stringify(candidates)}`, code: 1 });
     }
     return value as string[] extends KS ? never : KS[number];
   }


### PR DESCRIPTION
```ts
  // In actual code, you don't need to write such types, you can leave it to inference.
  type WantType = { name: string; direction: "north" | "south" | "east" | "west" };
  type GotType = { name: string; direction: string };

  // parse arguments
  const args: GotType = parseArgs(Deno.args, options);

  // restrict to desired type
  const restriction = new Restriction(options);
  const args2: WantType = { ...args, direction: restriction.choices(args.direction, directions) };
```

- refine for #22 