### PR TITLE
fix: prevent error with bind this

### DIFF
--- a/parse-args.ts
+++ b/parse-args.ts
@@ -234,7 +234,10 @@ export class Restriction {
     private readonly options: Options,
     private readonly supressHelp: boolean = false, // supress help message if error
     private readonly _handler: Handler = denoHandler,
-  ) {}
+  ) {
+    // prevent error in runtime (e.g. `const choices = moreStrict(args).choices; and choices("foo", ["bar"]);`)
+    this.choices = this.choices.bind(this);
+  }
 
   choices<const KS extends readonly string[]>(value: string, candidates: KS): string[] extends KS ? never : KS[number] {
     if (!candidates.includes(value)) {


### PR DESCRIPTION
```
$ deno run examples/use-choices.ts --direction foo
error: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'supressHelp')
      if (!this.supressHelp) {
                ^
    at choices (file:///home/po/ghq/github.com/podhmo/with-help/parse-args.ts:241:17)
    at main (file:///home/po/ghq/github.com/podhmo/with-help/examples/use-choices.ts:26:49)
    at file:///home/po/ghq/github.com/podhmo/with-help/examples/use-choices.ts:32:3
```